### PR TITLE
chore(git): add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Longtail Additions
+
+### Environment ###
+.env
+
+
 # Created by https://www.gitignore.io/api/linux,macos,django,windows
 # Edit at https://www.gitignore.io/?templates=linux,macos,django,windows
 


### PR DESCRIPTION
I'm surprised that this was not part of gitignore.io's default