### PR TITLE
fix: use serializer correctly

### DIFF
--- a/pangea/core/serializers.py
+++ b/pangea/core/serializers.py
@@ -29,7 +29,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class OrganizationAddUserSerializer(serializers.Serializer):
-    user_uuid = serializers.UUIDField()
+    user = serializers.PrimaryKeyRelatedField(queryset=PangeaUser.objects.all())
 
 
 class SampleGroupSerializer(serializers.ModelSerializer):

--- a/pangea/core/tests/test_api.py
+++ b/pangea/core/tests/test_api.py
@@ -54,7 +54,7 @@ class OrganizationMembershipTests(APITestCase):
 
     def add_target_user(self):
         url = reverse('organization-users', kwargs={'organization_pk': self.organization.pk})
-        data = {'user_uuid': self.target_user.pk}
+        data = {'user': self.target_user.pk}
         response = self.client.post(url, data, format='json')
         return response
 


### PR DESCRIPTION
This is a breaking change in the API. `user_uuid` --> `user`