### PR TITLE
Feature: Add Upwards Nested Serialization

### DIFF
--- a/pangea/core/serializers.py
+++ b/pangea/core/serializers.py
@@ -61,13 +61,16 @@ class SampleSerializer(serializers.ModelSerializer):
 
 class SampleAnalysisResultSerializer(serializers.ModelSerializer):
 
+    sample_obj = SampleSerializer(source='sample')
+
     class Meta:
         model = SampleAnalysisResult
         fields = (
             'uuid', 'module_name', 'replicate',
             'sample', 'created_at', 'updated_at',
+            'sample_obj'
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'sample_obj')
 
 
 class SampleGroupAnalysisResultSerializer(serializers.ModelSerializer):

--- a/pangea/core/serializers.py
+++ b/pangea/core/serializers.py
@@ -34,14 +34,16 @@ class OrganizationAddUserSerializer(serializers.Serializer):
 
 class SampleGroupSerializer(serializers.ModelSerializer):
 
+    organization_obj = OrganizationSerializer(source='organization')
+
     class Meta:
         model = SampleGroup
         fields = (
             'uuid', 'name', 'created_at', 'updated_at',
             'organization', 'description', 'is_library',
-            'is_public', 'theme'
+            'is_public', 'theme', 'organization_obj'
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'organization_obj')
 
 
 class SampleGroupAddSampleSerializer(serializers.Serializer):
@@ -50,13 +52,15 @@ class SampleGroupAddSampleSerializer(serializers.Serializer):
 
 class SampleSerializer(serializers.ModelSerializer):
 
+    library_obj = SampleGroupSerializer(source='library')
+
     class Meta:
         model = Sample
         fields = (
             'uuid', 'name', 'created_at', 'updated_at',
-            'library', 'metadata',
+            'library', 'metadata', 'library_obj',
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'library_obj')
 
 
 class SampleAnalysisResultSerializer(serializers.ModelSerializer):
@@ -75,32 +79,41 @@ class SampleAnalysisResultSerializer(serializers.ModelSerializer):
 
 class SampleGroupAnalysisResultSerializer(serializers.ModelSerializer):
 
+    sample_group_obj = SampleGroupSerializer(source='sample_group')
+
     class Meta:
         model = SampleGroupAnalysisResult
         fields = (
             'uuid', 'module_name', 'replicate',
             'sample_group', 'created_at', 'updated_at',
+            'sample_group_obj',
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'sample_group_obj')
 
 
 class SampleAnalysisResultFieldSerializer(serializers.ModelSerializer):
+
+    analysis_result_obj = SampleAnalysisResultSerializer(source='analysis_result')
 
     class Meta:
         model = SampleAnalysisResultField
         fields = (
             'uuid', 'name', 'created_at', 'updated_at',
             'stored_data', 'analysis_result',
+            'analysis_result_obj',
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'analysis_result_obj')
 
 
 class SampleGroupAnalysisResultFieldSerializer(serializers.ModelSerializer):
+
+    analysis_result_obj = SampleGroupAnalysisResultSerializer(source='analysis_result')
 
     class Meta:
         model = SampleGroupAnalysisResultField
         fields = (
             'uuid', 'name', 'created_at', 'updated_at',
             'stored_data', 'analysis_result',
+            'analysis_result_obj',
         )
-        read_only_fields = ('created_at', 'updated_at')
+        read_only_fields = ('created_at', 'updated_at', 'analysis_result_obj')

--- a/pangea/core/serializers.py
+++ b/pangea/core/serializers.py
@@ -34,7 +34,7 @@ class OrganizationAddUserSerializer(serializers.Serializer):
 
 class SampleGroupSerializer(serializers.ModelSerializer):
 
-    organization_obj = OrganizationSerializer(source='organization')
+    organization_obj = OrganizationSerializer(source='organization', read_only=True)
 
     class Meta:
         model = SampleGroup
@@ -52,7 +52,7 @@ class SampleGroupAddSampleSerializer(serializers.Serializer):
 
 class SampleSerializer(serializers.ModelSerializer):
 
-    library_obj = SampleGroupSerializer(source='library.group')
+    library_obj = SampleGroupSerializer(source='library.group', read_only=True)
 
     class Meta:
         model = Sample
@@ -65,7 +65,7 @@ class SampleSerializer(serializers.ModelSerializer):
 
 class SampleAnalysisResultSerializer(serializers.ModelSerializer):
 
-    sample_obj = SampleSerializer(source='sample')
+    sample_obj = SampleSerializer(source='sample', read_only=True)
 
     class Meta:
         model = SampleAnalysisResult
@@ -79,7 +79,7 @@ class SampleAnalysisResultSerializer(serializers.ModelSerializer):
 
 class SampleGroupAnalysisResultSerializer(serializers.ModelSerializer):
 
-    sample_group_obj = SampleGroupSerializer(source='sample_group')
+    sample_group_obj = SampleGroupSerializer(source='sample_group', read_only=True)
 
     class Meta:
         model = SampleGroupAnalysisResult
@@ -93,7 +93,7 @@ class SampleGroupAnalysisResultSerializer(serializers.ModelSerializer):
 
 class SampleAnalysisResultFieldSerializer(serializers.ModelSerializer):
 
-    analysis_result_obj = SampleAnalysisResultSerializer(source='analysis_result')
+    analysis_result_obj = SampleAnalysisResultSerializer(source='analysis_result', read_only=True)
 
     class Meta:
         model = SampleAnalysisResultField
@@ -107,7 +107,8 @@ class SampleAnalysisResultFieldSerializer(serializers.ModelSerializer):
 
 class SampleGroupAnalysisResultFieldSerializer(serializers.ModelSerializer):
 
-    analysis_result_obj = SampleGroupAnalysisResultSerializer(source='analysis_result')
+    analysis_result_obj = SampleGroupAnalysisResultSerializer(source='analysis_result',
+                                                              read_only=True)
 
     class Meta:
         model = SampleGroupAnalysisResultField

--- a/pangea/core/serializers.py
+++ b/pangea/core/serializers.py
@@ -52,7 +52,7 @@ class SampleGroupAddSampleSerializer(serializers.Serializer):
 
 class SampleSerializer(serializers.ModelSerializer):
 
-    library_obj = SampleGroupSerializer(source='library')
+    library_obj = SampleGroupSerializer(source='library.group')
 
     class Meta:
         model = Sample


### PR DESCRIPTION
When serializing objects we often want detailed information about the owner of our current object. A Pangea-ish way to do this is to serialize all fields of the parent within the current objects serialization. If the parent's object contains the grandparent's serialization, etc we have nested data.

Going down the object relationship tree isn't particularly feasible because we could end up with HUGE objects but going up the tree should keep the size manageable.