### PR TITLE
Clean Up Permissions and API

### DIFF
--- a/pangea/core/nested_urls.py
+++ b/pangea/core/nested_urls.py
@@ -17,6 +17,7 @@ Additional URLs that support nested access and access by name.
 '''
 
 from django.urls import path
+from django.db.models.functions import Lower
 from uuid import UUID
 from rest_framework.urlpatterns import format_suffix_patterns
 
@@ -74,13 +75,13 @@ def to_uuid(**kwargs):
     if is_uuid(org_key):
         parent = Organization.objects.get(pk=org_key)
     else:
-        parent = Organization.objects.get(name=org_key)
+        parent = Organization.objects.get(name__iexact=org_key)
 
     # Traverse down through whichever path segments present in the request
     for uuid_key, parent_key_name, model, field_name in keys:
         if uuid_key not in kwargs:
             break
-        filter_field = 'pk' if is_uuid(kwargs[uuid_key]) else 'name'
+        filter_field = 'pk' if is_uuid(kwargs[uuid_key]) else 'name__iexact'
         parent = model.objects.get(**{
             parent_key_name: parent.uuid,
             filter_field: kwargs[uuid_key],

--- a/pangea/core/permissions.py
+++ b/pangea/core/permissions.py
@@ -70,7 +70,8 @@ class SamplePermission(permissions.BasePermission):
             return False
 
         # Require organization membership to edit/delete
-        return request.user.organization_set.filter(pk=obj.library.group.organization.pk).exists()
+        organization = grp.organization
+        return request.user.organization_set.filter(pk=organization.pk).exists()
 
 
 class SampleAnalysisResultPermission(permissions.BasePermission):

--- a/pangea/core/tests/test_api.py
+++ b/pangea/core/tests/test_api.py
@@ -132,6 +132,22 @@ class SampleGroupTests(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_no_login_sample_group_list(self):
+        """Ensure 403 error is thrown if trying to illicitly read private group."""
+        pub_group = self.organization.create_sample_group(
+            name='GRP_01 PUBLIC_GJYJYIBSBN', is_public=True
+        )
+        other_org = Organization.objects.create(name='Test Organization GJYJYIBSBN')
+        priv_group = other_org.create_sample_group(
+            name='GRP_01 PRIVATE_GJYJYIBSBN', is_public=False
+        )
+        url = reverse('sample-group-create')
+        response = self.client.get(url, format='json')
+        names = {el['name'] for el in response.data['results']}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(pub_group.name, names)
+        self.assertNotIn(priv_group.name, names)
+
     def test_create_unauthenticated_sample_group(self):
         """Ensure 403 error is throw when trying to create sample group if unauthenticated."""
         url = reverse('sample-group-create')
@@ -221,6 +237,24 @@ class SampleTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_no_login_sample_list(self):
+        """Ensure 403 error is thrown if trying to illicitly read private group."""
+        pub_group = self.organization.create_sample_group(
+            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True
+        )
+        pub_samp = pub_group.create_sample('SMPL PUBLIC_RTJNDRPOF')
+        other_org = Organization.objects.create(name='Test Organization RTJNDRPOF')
+        priv_group = other_org.create_sample_group(
+            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False
+        )
+        priv_samp = priv_group.create_sample('SMPL PRIVATE_RTJNDRPOF')
+        url = reverse('sample-create')
+        response = self.client.get(url, format='json')
+        names = {el['name'] for el in response.data['results']}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(pub_samp.name, names)
+        self.assertNotIn(priv_samp.name, names)
 
     def test_create_unauthenticated_sample(self):
         """Ensure 403 error is throw when trying to create sample if unauthenticated."""
@@ -376,6 +410,26 @@ class AnalysisResultTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_no_login_sample_analys_result_list(self):
+        """Ensure 403 error is thrown if trying to illicitly read private group."""
+        pub_group = self.organization.create_sample_group(
+            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True
+        )
+        pub_samp = pub_group.create_sample('SMPL PUBLIC_RTJNDRPOF')
+        pub_ar = pub_samp.create_analysis_result(module_name='module_foobar')
+        other_org = Organization.objects.create(name='Test Organization RTJNDRPOF')
+        priv_group = other_org.create_sample_group(
+            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False
+        )
+        priv_samp = priv_group.create_sample('SMPL PRIVATE_RTJNDRPOF')
+        priv_ar = pub_samp.create_analysis_result(module_name='module_foobar')
+        url = reverse('sample-ars-create')
+        response = self.client.get(url, format='json')
+        names = {el['name'] for el in response.data['results']}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(pub_ar.name, names)
+        self.assertNotIn(priv_ar.name, names)
 
     def test_create_sample_group_analysis_result(self):
         self.client.force_authenticate(user=self.user)

--- a/pangea/core/tests/test_api.py
+++ b/pangea/core/tests/test_api.py
@@ -135,11 +135,11 @@ class SampleGroupTests(APITestCase):
     def test_no_login_sample_group_list(self):
         """Ensure 403 error is thrown if trying to illicitly read private group."""
         pub_group = self.organization.create_sample_group(
-            name='GRP_01 PUBLIC_GJYJYIBSBN', is_public=True
+            name='GRP_01 PUBLIC_GJYJYIBSBN', is_public=True, is_library=True
         )
         other_org = Organization.objects.create(name='Test Organization GJYJYIBSBN')
         priv_group = other_org.create_sample_group(
-            name='GRP_01 PRIVATE_GJYJYIBSBN', is_public=False
+            name='GRP_01 PRIVATE_GJYJYIBSBN', is_public=False, is_library=True
         )
         url = reverse('sample-group-create')
         response = self.client.get(url, format='json')
@@ -241,14 +241,15 @@ class SampleTests(APITestCase):
     def test_no_login_sample_list(self):
         """Ensure 403 error is thrown if trying to illicitly read private group."""
         pub_group = self.organization.create_sample_group(
-            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True
+            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True, is_library=True
         )
-        pub_samp = pub_group.create_sample('SMPL PUBLIC_RTJNDRPOF')
+        pub_samp = pub_group.create_sample(name='SMPL PUBLIC_RTJNDRPOF')
         other_org = Organization.objects.create(name='Test Organization RTJNDRPOF')
         priv_group = other_org.create_sample_group(
-            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False
+            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False, is_library=True
         )
-        priv_samp = priv_group.create_sample('SMPL PRIVATE_RTJNDRPOF')
+        priv_samp = priv_group.create_sample(name='SMPL PRIVATE_RTJNDRPOF')
+
         url = reverse('sample-create')
         response = self.client.get(url, format='json')
         names = {el['name'] for el in response.data['results']}
@@ -411,25 +412,25 @@ class AnalysisResultTests(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_no_login_sample_analys_result_list(self):
+    def test_no_login_sample_analysis_result_list(self):
         """Ensure 403 error is thrown if trying to illicitly read private group."""
         pub_group = self.organization.create_sample_group(
-            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True
+            name='GRP_01 PUBLIC_RTJNDRPOF', is_public=True, is_library=True
         )
-        pub_samp = pub_group.create_sample('SMPL PUBLIC_RTJNDRPOF')
+        pub_samp = pub_group.create_sample(name='SMPL PUBLIC_RTJNDRPOF')
         pub_ar = pub_samp.create_analysis_result(module_name='module_foobar')
         other_org = Organization.objects.create(name='Test Organization RTJNDRPOF')
         priv_group = other_org.create_sample_group(
-            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False
+            name='GRP_01 PRIVATE_RTJNDRPOF', is_public=False, is_library=True
         )
-        priv_samp = priv_group.create_sample('SMPL PRIVATE_RTJNDRPOF')
+        priv_samp = priv_group.create_sample(name='SMPL PRIVATE_RTJNDRPOF')
         priv_ar = pub_samp.create_analysis_result(module_name='module_foobar')
         url = reverse('sample-ars-create')
         response = self.client.get(url, format='json')
-        names = {el['name'] for el in response.data['results']}
+        names = {el['sample_obj']['name'] for el in response.data['results']}
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn(pub_ar.name, names)
-        self.assertNotIn(priv_ar.name, names)
+        self.assertIn(pub_samp.name, names)
+        self.assertNotIn(priv_samp.name, names)
 
     def test_create_sample_group_analysis_result(self):
         self.client.force_authenticate(user=self.user)

--- a/pangea/core/tests/test_nested_api.py
+++ b/pangea/core/tests/test_nested_api.py
@@ -58,6 +58,19 @@ class NestedSampleGroupTests(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_retrieve_sample_group_case_insensitive(self):
+        """Ensure authorized user can create sample group."""
+        grp_name = 'Test Sample Group TRUGKH'
+        self.organization.create_sample_group(name=grp_name, is_public=True)
+
+        url = reverse('nested-sample-group-detail', kwargs={
+            'org_pk': self.organization.pk,
+            'grp_pk': grp_name.lower(),
+        })
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
 
 class NestedSampleTests(APITestCase):
 


### PR DESCRIPTION
Clean up permissions so that LIST operations won't show anything the user doesn't have permission to see

Make nested API queries case-insensitive (when the user provides names as opposed to UUIDS)